### PR TITLE
Some updates / improvements.

### DIFF
--- a/src/bluepill.ld
+++ b/src/bluepill.ld
@@ -37,4 +37,4 @@ SECTIONS
 }
 
 /* Include the common ld script from libopenstm32. */
-INCLUDE libopencm3_stm32f1.ld
+INCLUDE cortex-m-generic.ld

--- a/src/cdcacm.c
+++ b/src/cdcacm.c
@@ -152,9 +152,9 @@ static void cdcacm_set_modem_state(usbd_device *dev, int iface, bool dsr, bool d
 	usbd_ep_write_packet(dev, 0x82 + iface, buf, 10);
 }
 
-static int cdcacm_control_request(usbd_device *dev,
+static enum usbd_request_return_codes cdcacm_control_request(usbd_device *dev,
 		struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
-		void (**complete)(usbd_device *dev, struct usb_setup_data *req))
+		usbd_control_complete_callback *complete)
 {
 	(void)dev;
 	(void)complete;

--- a/src/hid.c
+++ b/src/hid.c
@@ -78,8 +78,8 @@ struct usb_interface_descriptor hid_iface = {
 	.extralen = sizeof(hid_function),
 };
 
-static int hid_control_request(usbd_device *dev, struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
-			void (**complete)(usbd_device *, struct usb_setup_data *))
+static enum usbd_request_return_codes hid_control_request(usbd_device *dev, struct usb_setup_data *req, uint8_t **buf, uint16_t *len,
+		usbd_control_complete_callback *complete)
 {
 	(void)complete;
 	(void)dev;


### PR DESCRIPTION
- LibopenCM3 updated to the current version. Some changes are needed to do that.

- The mouse-jiggler is started automaticly on the first start / after flashing the pill_duck.

- A button between PB9 and Vcc (either 3.3V or 5V) can be used to pause / resume the mouse-jiggler.

- The LED will be turned off, when in paused mode.
